### PR TITLE
Add automated database populating (#24)

### DIFF
--- a/data/blog_posts.sql
+++ b/data/blog_posts.sql
@@ -1,0 +1,20 @@
+-- Adminer 4.6.3 MySQL dump
+
+SET NAMES utf8;
+SET time_zone = '+00:00';
+SET foreign_key_checks = 0;
+SET sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
+
+SET NAMES utf8mb4;
+
+DROP TABLE IF EXISTS `blog_posts`;
+CREATE TABLE `blog_posts` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) NOT NULL,
+  `content` text NOT NULL,
+  `author` varchar(255) NOT NULL,
+  `created_at` date NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- 2018-08-03 05:08:01

--- a/data/users.sql
+++ b/data/users.sql
@@ -1,0 +1,22 @@
+-- Adminer 4.6.3 MySQL dump
+
+SET NAMES utf8;
+SET time_zone = '+00:00';
+SET foreign_key_checks = 0;
+SET sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
+
+SET NAMES utf8mb4;
+
+DROP TABLE IF EXISTS `users`;
+CREATE TABLE `users` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `token` varchar(255) NOT NULL,
+  `admin` tinyint(4) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+INSERT INTO `users` (`id`, `token`, `admin`) VALUES
+(1,	'auth0|596f27c2c3709661e9cea37d',	1),
+(2,	'auth0|596f27c2c3709661e9cea37e',	0);
+
+-- 2018-08-03 05:08:01

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,12 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: bloggo
     ports:
       - 3306:3306
+    volumes:
+      - ./data/blog_posts.sql:/docker-entrypoint-initdb.d/01-blog-posts.sql
+      - ./data/users.sql:/docker-entrypoint-initdb.d/02-users.sql
 
   adminer:
     image: adminer


### PR DESCRIPTION
## Goal of this PR

This PR adds scripts to automatically mount data in MySQL the first time it's ran. This initializes the database, the two required tables, and adds two users (one admin, one not).

This makes testing significantly easier.

Fixes #24 

## How to test this PR

* Run `docker-compose up`
* Visit `0.0.0.0:8080` in your favorite browser
* Make sure that the database is created
* Make sure that the `blog_posts` table is created
* Make sure that the `blog_posts` table is empty
* Make sure that the `users` table is created
* Make sure that the `users` table contains one admin user and one non-admin user

<img width="444" alt="screenshot 2018-08-03 at 07 30 34" src="https://user-images.githubusercontent.com/6976628/43625796-2dafab98-96ef-11e8-8785-707f713da606.png">
