### PR TITLE
Add unit test for blog controller - controller 100% coverage

### DIFF
--- a/controller/blog_test.go
+++ b/controller/blog_test.go
@@ -1,3 +1,277 @@
 package controller
 
-// TODO: Unit tests for blog controller
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Ullaakut/Bloggo/errorTypes"
+	"github.com/Ullaakut/Bloggo/logger"
+	"github.com/Ullaakut/Bloggo/model"
+	"github.com/Ullaakut/Bloggo/repo"
+
+	"github.com/labstack/echo"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// Define a custom error to imitate a gorm.ErrRecordNotFound without actually
+// importing gorm here
+type ResourceNotFoundErr struct {
+}
+
+func (r *ResourceNotFoundErr) Cause() error {
+	return errortypes.ErrNotFound
+}
+
+func (r *ResourceNotFoundErr) Error() string {
+	return errortypes.ErrNotFound.Error()
+}
+
+func TestNewBlog(t *testing.T) {
+	blogPostRepositoryMock := &repo.BlogPostRepositoryMock{}
+	logsBuff := &bytes.Buffer{}
+	log := logger.NewZeroLog(logsBuff)
+
+	b := NewBlog(log, blogPostRepositoryMock)
+
+	assert.Equal(t, blogPostRepositoryMock, b.posts, "unexpected blog post repository set")
+	assert.Equal(t, log, b.log, "unexpected logger set")
+}
+
+func TestCreate(t *testing.T) {
+	tests := []struct {
+		description string
+
+		requestBody     []byte
+		userIDMissing   bool
+		repositoryErr   error
+		createdBlogPost *model.BlogPost
+
+		expectedHTTPCode int
+		expectedHTTPBody []byte
+	}{
+		{
+			description: "created: passing test",
+
+			requestBody: []byte(`
+				{
+					"title": "lorem ipsum",
+					"content": "dolor sit amet"
+				}
+			`),
+			createdBlogPost: &model.BlogPost{
+				ID:        1,
+				Title:     "lorem ipsum",
+				Content:   "dolor sit amet",
+				Author:    "faketoken",
+				CreatedAt: time.Time{},
+			},
+
+			expectedHTTPCode: 201,
+			expectedHTTPBody: []byte(`{"id":1,"author":"faketoken","title":"lorem ipsum","content":"dolor sit amet","created_at":"0001-01-01T00:00:00Z"}`),
+		},
+		{
+			description: "bad request: bind fails",
+
+			requestBody: []byte(`Not json`),
+
+			expectedHTTPCode: 400,
+			expectedHTTPBody: []byte(`Syntax error: offset=1, error=invalid character 'N' looking for beginning of value`),
+		},
+		{
+			description: "internal server error: could not find userID in context",
+
+			requestBody:   []byte(`{}`),
+			userIDMissing: true,
+
+			expectedHTTPCode: 500,
+			expectedHTTPBody: []byte(`userID not set in request context`),
+		},
+		{
+			description: "unprocessable entity: invalid blog post",
+
+			requestBody: []byte(`{}`),
+
+			expectedHTTPCode: 422,
+			expectedHTTPBody: []byte(`Error:Field validation for 'Title' failed on the 'required' tag`),
+		},
+		{
+			description: "internal server error: repository failure",
+
+			requestBody: []byte(`
+				{
+					"title": "lorem ipsum",
+					"content": "dolor sit amet"
+				}
+			`),
+			repositoryErr:   errors.New("database exploded"),
+			createdBlogPost: nil,
+
+			expectedHTTPCode: 500,
+			expectedHTTPBody: []byte(`database exploded`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			// initialize the echo context to use for the test
+			e := echo.New()
+			r, err := http.NewRequest(echo.POST, "/posts", bytes.NewReader(test.requestBody))
+			if err != nil {
+				t.Fatal("could not create request")
+			}
+			r.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+
+			w := httptest.NewRecorder()
+			ctx := e.NewContext(r, w)
+
+			if !test.userIDMissing {
+				ctx.Set("userID", "fakeToken")
+			}
+
+			blogPostRepositoryMock := &repo.BlogPostRepositoryMock{}
+			if test.repositoryErr != nil || test.createdBlogPost != nil {
+				blogPostRepositoryMock.
+					On("Store", mock.Anything).
+					Return(test.createdBlogPost, test.repositoryErr).
+					Once()
+			}
+
+			logsBuff := &bytes.Buffer{}
+			log := logger.NewZeroLog(logsBuff)
+
+			blogController := &Blog{
+				posts: blogPostRepositoryMock,
+
+				log: log,
+			}
+
+			err = blogController.Create(ctx)
+
+			if err == nil {
+				assert.Equal(t, test.expectedHTTPCode, w.Code, "wrong response status")
+				assert.Equal(t, string(test.expectedHTTPBody), w.Body.String(), "wrong response body")
+			} else {
+				assert.Contains(t, err.Error(), fmt.Sprint(test.expectedHTTPCode), "wrong error response status")
+				if test.expectedHTTPBody != nil {
+					assert.Contains(t, err.Error(), string(test.expectedHTTPBody), "unexpected error response")
+				} else {
+					assert.Contains(t, w.Body, nil, "unexpected error response")
+				}
+			}
+
+			blogPostRepositoryMock.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRead(t *testing.T) {
+	tests := []struct {
+		description string
+
+		blogPostIDMissing bool
+		repositoryErr     error
+		retrievedBlogPost *model.BlogPost
+
+		expectedHTTPCode int
+		expectedHTTPBody []byte
+	}{
+		{
+			description: "created: passing test",
+
+			retrievedBlogPost: &model.BlogPost{
+				ID:        1,
+				Title:     "lorem ipsum",
+				Content:   "dolor sit amet",
+				Author:    "faketoken",
+				CreatedAt: time.Time{},
+			},
+
+			expectedHTTPCode: 200,
+			expectedHTTPBody: []byte(`{"id":1,"author":"faketoken","title":"lorem ipsum","content":"dolor sit amet","created_at":"0001-01-01T00:00:00Z"}`),
+		},
+		{
+			description: "bad request: missing blog post id",
+
+			blogPostIDMissing: true,
+
+			expectedHTTPCode: 400,
+			expectedHTTPBody: []byte(`could not parse blog post ID: strconv.ParseUint: parsing "": invalid syntax`),
+		},
+		{
+			description: "not found: blog post entity doesnt exist",
+
+			repositoryErr:     &ResourceNotFoundErr{},
+			retrievedBlogPost: nil,
+
+			expectedHTTPCode: 404,
+			expectedHTTPBody: []byte(`blog post id 42: resource not found`),
+		},
+		{
+			description: "internal server error: repository failure",
+
+			repositoryErr:     errors.New("database exploded"),
+			retrievedBlogPost: nil,
+
+			expectedHTTPCode: 500,
+			expectedHTTPBody: []byte(`could not read blog post: database exploded`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			// initialize the echo context to use for the test
+			e := echo.New()
+			r, err := http.NewRequest(echo.GET, "/posts/", nil)
+			if err != nil {
+				t.Fatal("could not create request")
+			}
+
+			w := httptest.NewRecorder()
+			ctx := e.NewContext(r, w)
+
+			if !test.blogPostIDMissing {
+				ctx.SetParamNames("id")
+				ctx.SetParamValues("42")
+			}
+
+			blogPostRepositoryMock := &repo.BlogPostRepositoryMock{}
+			if test.repositoryErr != nil || test.retrievedBlogPost != nil {
+				blogPostRepositoryMock.
+					On("Retrieve", uint(42)).
+					Return(test.retrievedBlogPost, test.repositoryErr).
+					Once()
+			}
+
+			logsBuff := &bytes.Buffer{}
+			log := logger.NewZeroLog(logsBuff)
+
+			blogController := &Blog{
+				posts: blogPostRepositoryMock,
+
+				log: log,
+			}
+
+			err = blogController.Read(ctx)
+
+			if err == nil {
+				assert.Equal(t, test.expectedHTTPCode, w.Code, "wrong response status")
+				assert.Equal(t, string(test.expectedHTTPBody), w.Body.String(), "wrong response body")
+			} else {
+				assert.Contains(t, err.Error(), fmt.Sprint(test.expectedHTTPCode), "wrong error response status")
+				if test.expectedHTTPBody != nil {
+					assert.Contains(t, err.Error(), string(test.expectedHTTPBody), "unexpected error response")
+				} else {
+					assert.Contains(t, w.Body, nil, "unexpected error response")
+				}
+			}
+
+			blogPostRepositoryMock.AssertExpectations(t)
+		})
+	}
+}

--- a/repo/blogPostRepositoryMock.go
+++ b/repo/blogPostRepositoryMock.go
@@ -17,9 +17,9 @@ func (m *BlogPostRepositoryMock) Store(content *model.BlogPost) (*model.BlogPost
 }
 
 // Retrieve mock
-func (m *BlogPostRepositoryMock) Retrieve(id uint) (model.BlogPost, error) {
+func (m *BlogPostRepositoryMock) Retrieve(id uint) (*model.BlogPost, error) {
 	args := m.Called(id)
-	return args.Get(0).(model.BlogPost), args.Error(1)
+	return args.Get(0).(*model.BlogPost), args.Error(1)
 }
 
 // TODO: Add Update

--- a/repo/blogPostRepositoryMySQL.go
+++ b/repo/blogPostRepositoryMySQL.go
@@ -39,17 +39,17 @@ func (r *BlogPostRepositoryMySQL) Store(content *model.BlogPost) (*model.BlogPos
 }
 
 // Retrieve returns the blog post with the given ID from the database
-func (r *BlogPostRepositoryMySQL) Retrieve(id uint) (model.BlogPost, error) {
+func (r *BlogPostRepositoryMySQL) Retrieve(id uint) (*model.BlogPost, error) {
 	post := model.BlogPost{
 		ID: id,
 	}
 
 	err := r.db.Where(&post).First(&post).Error
 	if err == gorm.ErrRecordNotFound {
-		return post, errortypes.ErrNotFound
+		return &post, errortypes.ErrNotFound
 	}
 
-	return post, err
+	return &post, err
 }
 
 // TODO: Add Update

--- a/service/access_test.go
+++ b/service/access_test.go
@@ -28,7 +28,7 @@ func TestValidateToken(t *testing.T) {
 	validSub := "auth0|596f27c2c3709661e9cea37d"
 	invalidSub := "auth1|596f27c2c3709661e9cea37d"
 
-	testCases := []struct {
+	tests := []struct {
 		description string
 
 		token         string
@@ -111,8 +111,8 @@ func TestValidateToken(t *testing.T) {
 		},
 	}
 
-	for idx, testCase := range testCases {
-		t.Run(testCase.description, func(t *testing.T) {
+	for idx, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
 			userRepositoryMock := &repo.UserRepositoryMock{}
 
 			logsBuff := &bytes.Buffer{}
@@ -124,18 +124,18 @@ func TestValidateToken(t *testing.T) {
 				trustedSource: "https://samples.auth0.com/",
 			}
 
-			if !testCase.tokenErr {
-				userRepositoryMock.On("Retrieve", validSub).Return(true, testCase.repositoryErr)
+			if !test.tokenErr {
+				userRepositoryMock.On("Retrieve", validSub).Return(true, test.repositoryErr)
 				userRepositoryMock.On("Retrieve", invalidSub).Return(true, errors.New("user not found"))
 			}
 
-			userID, err := a.ValidateToken(testCase.token)
+			userID, err := a.ValidateToken(test.token)
 
-			if testCase.expectedError != nil {
+			if test.expectedError != nil {
 				assert.NotEqual(t, nil, err, "unexpected success in test case %d", idx)
-				assert.Equal(t, testCase.expectedError.Error(), err.Error(), "wrong error returned in test case %d", idx)
+				assert.Equal(t, test.expectedError.Error(), err.Error(), "wrong error returned in test case %d", idx)
 			} else {
-				assert.Equal(t, testCase.expectedUserID, userID, "unexpected userID in test case %d", idx)
+				assert.Equal(t, test.expectedUserID, userID, "unexpected userID in test case %d", idx)
 				assert.Equal(t, nil, err, "unexpected error in test case %d", idx)
 			}
 		})


### PR DESCRIPTION
## Goal of this PR

Before I start adding new features to the blog controller, I should start unit testing the existing code. This way, every time I add a feature to the blog controller, I'll be able to just add a unit test for it to the already existing ones.

Fixes #5 

## How to test this PR

* Run `go test controller/*.go` from the root of the repository to make sure tests are passing
* Run `go test controller/*.go -coverprofile=cover.out ; go tool cover -html=cover.out -o coverage.html ; open coverage.html ; rm -f cover.out coverage.html` to see test coverage

<img width="807" alt="screenshot 2018-08-03 at 18 14 30" src="https://user-images.githubusercontent.com/6976628/43653699-24c11530-9749-11e8-9768-a65a904ee657.png">
<img width="963" alt="screenshot 2018-08-03 at 18 14 40" src="https://user-images.githubusercontent.com/6976628/43653700-24deacb2-9749-11e8-8744-13741d19919b.png">
