### PR TITLE
Add ReadAll route (#29)

### DIFF
--- a/controller/blog.go
+++ b/controller/blog.go
@@ -17,6 +17,7 @@ import (
 // BlogRepository represents a repository that allows to create, read, update and delete blog posts
 type BlogRepository interface {
 	Retrieve(id uint) (*model.BlogPost, error)
+	RetrieveAll() ([]*model.BlogPost, error)
 	Store(post *model.BlogPost) (*model.BlogPost, error)
 }
 
@@ -97,8 +98,13 @@ func (b *Blog) Read(ctx echo.Context) error {
 
 // ReadAll retrieves all blog posts
 func (b *Blog) ReadAll(ctx echo.Context) error {
-	// TODO: Implement this func
-	return nil
+	blogPosts, err := b.posts.RetrieveAll()
+	if err != nil {
+		err = errors.Wrap(err, "could not read blog posts")
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return ctx.JSON(http.StatusOK, blogPosts)
 }
 
 // Update edits a blog post from its id

--- a/repo/blogPostRepositoryMock.go
+++ b/repo/blogPostRepositoryMock.go
@@ -22,7 +22,12 @@ func (m *BlogPostRepositoryMock) Retrieve(id uint) (*model.BlogPost, error) {
 	return args.Get(0).(*model.BlogPost), args.Error(1)
 }
 
+// RetrieveAll mock
+func (m *BlogPostRepositoryMock) RetrieveAll() ([]*model.BlogPost, error) {
+	args := m.Called()
+	return args.Get(0).([]*model.BlogPost), args.Error(1)
+}
+
 // TODO: Add Update
 // TODO: Add Delete
-// TODO: Add RetrieveAll
 // TODO: Add Find? Retrieve with filters could be cool (filter by id, author, etc.)

--- a/repo/blogPostRepositoryMySQL.go
+++ b/repo/blogPostRepositoryMySQL.go
@@ -52,7 +52,14 @@ func (r *BlogPostRepositoryMySQL) Retrieve(id uint) (*model.BlogPost, error) {
 	return &post, err
 }
 
+// RetrieveAll returns the blog post with the given ID from the database
+func (r *BlogPostRepositoryMySQL) RetrieveAll() ([]*model.BlogPost, error) {
+	var posts []*model.BlogPost
+
+	err := r.db.Find(&posts).Error
+	return posts, err
+}
+
 // TODO: Add Update
 // TODO: Add Delete
-// TODO: Add RetrieveAll
 // TODO: Add Find? Retrieve with filters could be cool (filter by id, author, etc.)


### PR DESCRIPTION
## Goal of this PR

A route to get all existing blog posts will be useful. Makes it easy to test, no need to change the request with the created blog post IDs every time :)

Also, very useful for building a frontend on top of it, as you're most likely to want to get all of the events to display them. A route to get the event IDs only or to get a paginated version of this would be idea though, if we were to really build a frontend. (#33)

Fixes #29 

## How to test it

* `docker-compose up`
* `go run *.go`
* Create a few blog posts like such

```
curl -X POST \
       http://0.0.0.0:4242/posts \
       -H 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6ImJyZW5kYW4ubGUtZ2xhdW5lYyt0ZXN0YXBpQGVwaXRlY2guZXUiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImlzcyI6Imh0dHBzOi8vc2FtcGxlcy5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTk2ZjI3YzJjMzcwOTY2MWU5Y2VhMzdkIiwiYXVkIjoia2J5dUZEaWRMTG0yODBMSXdWRmlhek9xak8zdHk4S0giLCJleHAiOjE2MDA0OTI5NjUsImlhdCI6MTUwMDQ1Njk2NX0.4To8mYgu4pM7J2G5jBTnKWelCTU1U1jo0QOENVp3pOk' \
       H 'Cache-Control: no-cache' \
       -H 'Content-Type: application/json' \
       -d '{
                  "title": "Lorem ipsum",
                  "content": "Dolor sit amet"
       }'
```

* Run this query, you should get the list of all of the blog posts you previously created

```
curl -X GET http://0.0.0.0:4242/posts
```

## Screenshots

<img width="629" alt="screenshot 2018-08-03 at 18 31 39" src="https://user-images.githubusercontent.com/6976628/43654428-7c656c76-974b-11e8-92ad-6e23268b7a31.png">

<img width="958" alt="screenshot 2018-08-03 at 18 34 00" src="https://user-images.githubusercontent.com/6976628/43654518-cfe6908c-974b-11e8-8f5b-4441f69d7126.png">
