### PR TITLE
Add API blueprints (#4)

### DIFF
--- a/blueprints/main.apib
+++ b/blueprints/main.apib
@@ -1,1 +1,2 @@
-// TODO: Import models & routes
+<!-- include(models.apib) -->
+<!-- include(posts.apib) -->

--- a/blueprints/models.apib
+++ b/blueprints/models.apib
@@ -1,1 +1,35 @@
-// TODO: Define BlogPost model
+# Bloggo API
+
+# Data Structures
+
+## BadRequest (object)
++ code: 400 (number)
++ name: Bad Request (string)
++ message: Bad Request (string)
+
+## Unauthorized (object)
++ code: 401 (number)
++ name: Unauthorized (string)
++ message: Unauthorized (string)
+
+## NotFound (object)
++ code: 404 (number)
++ name: Not Found (string)
++ message: Not Found (string)
+
+## UnprocessableEntity (object)
++ code: 422 (number)
++ name: UnprocessableEntity (string)
++ message: UnprocessableEntity (string)
+
+## InternalServerError (object)
++ code: 500 (number)
++ name: Internal Server Error (string)
++ message: Internal Server Error (string)
+
+## BlogPost (object)
++ id: 1 (number) - database identifier
++ author: auth0|596f27c2c3709661e9cea37d (string) - the post's author's user id
++ title: `how to eat chinese food` (string) - the blog post's title
++ content: `using chopsticks` (string) - the blog post's content
++ created_at: "2018-08-03T00:00:00+02:00" (string) - blog post's creation date

--- a/blueprints/posts.apib
+++ b/blueprints/posts.apib
@@ -1,14 +1,44 @@
-# Bloggo API
+# Group blog posts
 
-The API of the Bloggo service.
-TODO: Finish the blueprint
-TODO: Show necessary authentication headers in API blueprint
+## Blog posts [/posts]
 
-## /posts
+All of Bloggo's posts
 
-### Get all posts [GET]
+### Create a new blog post [POST]
 
-This path returns the list of all of the blog posts currently stored in the database
+Creates a new blog post
+
++ Request
+
+    + Headers
+
+            Accept: application/json
+
+            Content-Type: application/json
+
+    + Attributes (BlogPost)
+
++ Response 201 (application/json)
+
+    The created blog post
+
+    + Attributes (BlogPost)
+
++ Response 400 (application/json)
+
+    + Attributes (BadRequest)
+
++ Response 422 (application/json)
+
+    + Attributes (UnprocessableEntity)
+
++ Response 500 (application/json)
+
+  + Attributes (InternalServerError)
+
+### Get all blog posts [GET]
+
+Returns the list of all of the blog posts currently stored in the database
 
 + Request
 
@@ -23,3 +53,105 @@ This path returns the list of all of the blog posts currently stored in the data
     An array of blog posts
 
     + Attributes (array[BlogPost])
+
++ Response 500 (application/json)
+
+  + Attributes (InternalServerError)
+
+## A specific blog post [/posts/{id}]
+
+A blog post that already exists in the database.
+
++ Parameters
+
+    + id: `1` (required, number) - The blog post's database identifier
+
+### Get a blog post [GET]
+
+Returns the list of all of the blog posts currently stored in the database
+
++ Request
+
+    + Headers
+
+            Accept: application/json
+
+    + Body
+
++ Response 200 (application/json)
+
+    An array of blog posts
+
+    + Attributes (array[BlogPost])
+
++ Response 400 (application/json)
+
+  + Attributes (BadRequest)
+
++ Response 404 (application/json)
+
+  + Attributes (NotFound)
+
++ Response 500 (application/json)
+
+  + Attributes (InternalServerError)
+
+### Update a blog post [PUT]
+
+Updates a blog post currently stored in the database
+
++ Request
+
+    + Headers
+
+            Content-Type: application/json
+
+    + Attributes (BlogPost)
+
++ Response 204
+
+    The blog post has been successfully updated
+
+    + Body
+
++ Response 400 (application/json)
+
+  + Attributes (BadRequest)
+
++ Response 422 (application/json)
+
+    + Attributes (UnprocessableEntity)
+
++ Response 500 (application/json)
+
+  + Attributes (InternalServerError)
+
+### Delete a blog post [DELETE]
+
+Deletes a blog post currently stored in the database
+
++ Request
+
+    + Headers
+
+            Accept: application/json
+
+    + Body
+
++ Response 204
+
+    The blog post has been successfully deleted
+
+    + Body
+
++ Response 400 (application/json)
+
+  + Attributes (BadRequest)
+
++ Response 404 (application/json)
+
+    + Attributes (NotFound)
+
++ Response 500 (application/json)
+
+  + Attributes (InternalServerError)


### PR DESCRIPTION
## Goal of this PR

API blueprints are great to document an API. They're easy to maintain and I can make a small docker container that will be deployed alongside the API and the database, that will expose the API documentation on an http endpoint.

Fixes #4 

## How to test this PR

0. `npm install -g aglio` // No worries, soon this will be dockerized and there won't be npm dependencies
1. `cd blueprints`
2. `aglio --theme-variables slate -i main.apib -s`
3. Visit `http://127.0.0.1:3000/#blog-posts` in your favorite browser

## Screenshots

<img width="1362" alt="screenshot 2018-08-03 at 20 55 27" src="https://user-images.githubusercontent.com/6976628/43660729-23b3a326-9760-11e8-9c7d-8d425eff6c02.png">