### PR TITLE
Dockerize the Bloggo & API documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Build stage
+FROM golang:alpine AS build-env
+
+COPY . /go/src/github.com/Ullaakut/Bloggo
+WORKDIR /go/src/github.com/Ullaakut/Bloggo
+
+RUN apk update && \
+    apk upgrade && \
+    apk add nmap nmap-nselibs nmap-scripts \
+    curl curl-dev \
+    gcc \
+    libc-dev \
+    git \
+    pkgconfig
+ENV DEP_VERSION="0.4.1"
+RUN curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
+RUN chmod +x $GOPATH/bin/dep
+RUN dep ensure
+RUN go build -o bloggo
+
+# Final stage
+FROM alpine
+
+WORKDIR /app/bloggo
+COPY --from=build-env /go/src/github.com/Ullaakut/Bloggo /app/bloggo
+ENTRYPOINT ["/app/bloggo/bloggo"]

--- a/README.md
+++ b/README.md
@@ -13,11 +13,20 @@ Bloggo is a blog CRUD that uses JWT tokens for authorization. See [OpenID Connec
 
 ## Deployment
 
-* `docker-compose up` // TODO: Add Dockerfile & docker-compose file
+* `docker-compose up`
 
-## API
+## API Blueprints
 
-See [API blueprints](TODO).
+* `docker-compose up blueprints`
+* Visit `0.0.0.0:3000` in your favorite browser
+
+<img width="500" alt="screenshot 2018-08-03 at 20 55 27" src="https://user-images.githubusercontent.com/6976628/43660729-23b3a326-9760-11e8-9c7d-8d425eff6c02.png">
+
+## Postman collection
+
+* Import the [collection](/postman/Bloggo.postman_collection.json) in Postman.
+
+<img width="161" alt="screenshot 2018-08-03 at 20 10 31" src="https://user-images.githubusercontent.com/6976628/43658775-1dd15cf6-975a-11e8-82c0-258732e24ff9.png">
 
 ## Testing
 
@@ -40,24 +49,9 @@ TODO: Add benchmarks + add previous benchmark of token parsing
 
 See the [issues](https://github.com/Ullaakut/Bloggo/issues?q=is%3Aopen+is%3Aissue+milestone%3A%22Potential+future+improvements%22) and [projects](https://github.com/Ullaakut/Blogger/projects/2) pages for a list of possible improvements that could be done in the next 14 days.
 
-## Help
-
-### Required Claims
-
-```json
-{
-    "iss": "https://samples.auth0.com/",
-    "sub": "" // TODO: Get admin account and update this
-  }
-```
-
 ### Example of a valid token
 
 `eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6ImJyZW5kYW4ubGUtZ2xhdW5lYyt0ZXN0YXBpQGVwaXRlY2guZXUiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImlzcyI6Imh0dHBzOi8vc2FtcGxlcy5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTk2ZjI3YzJjMzcwOTY2MWU5Y2VhMzdkIiwiYXVkIjoia2J5dUZEaWRMTG0yODBMSXdWRmlhek9xak8zdHk4S0giLCJleHAiOjE2MDA0OTI5NjUsImlhdCI6MTUwMDQ1Njk2NX0.4To8mYgu4pM7J2G5jBTnKWelCTU1U1jo0QOENVp3pOk`
-
-### Example of an invalid token
-
-TODO: Add invalid token
 
 ### Notes
 

--- a/blueprints/Dockerfile
+++ b/blueprints/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:6
+
+RUN npm install -g aglio
+COPY . .
+
+CMD ["bash", "-c", "aglio -h 0.0.0.0 -i main.apib --theme-variables slate -s"]

--- a/blueprints/main.apib
+++ b/blueprints/main.apib
@@ -1,1 +1,2 @@
-// TODO: Import models & routes
+<!-- include(models.apib) -->
+<!-- include(posts.apib) -->

--- a/blueprints/models.apib
+++ b/blueprints/models.apib
@@ -1,1 +1,35 @@
-// TODO: Define BlogPost model
+# Bloggo API
+
+# Data Structures
+
+## BadRequest (object)
++ code: 400 (number)
++ name: Bad Request (string)
++ message: Bad Request (string)
+
+## Unauthorized (object)
++ code: 401 (number)
++ name: Unauthorized (string)
++ message: Unauthorized (string)
+
+## NotFound (object)
++ code: 404 (number)
++ name: Not Found (string)
++ message: Not Found (string)
+
+## UnprocessableEntity (object)
++ code: 422 (number)
++ name: UnprocessableEntity (string)
++ message: UnprocessableEntity (string)
+
+## InternalServerError (object)
++ code: 500 (number)
++ name: Internal Server Error (string)
++ message: Internal Server Error (string)
+
+## BlogPost (object)
++ id: 1 (number) - database identifier
++ author: auth0|596f27c2c3709661e9cea37d (string) - the post's author's user id
++ title: `how to eat chinese food` (string) - the blog post's title
++ content: `using chopsticks` (string) - the blog post's content
++ created_at: "2018-08-03T00:00:00+02:00" (string) - blog post's creation date

--- a/blueprints/posts.apib
+++ b/blueprints/posts.apib
@@ -1,14 +1,44 @@
-# Bloggo API
+# Group blog posts
 
-The API of the Bloggo service.
-TODO: Finish the blueprint
-TODO: Show necessary authentication headers in API blueprint
+## Blog posts [/posts]
 
-## /posts
+All of Bloggo's posts
 
-### Get all posts [GET]
+### Create a new blog post [POST]
 
-This path returns the list of all of the blog posts currently stored in the database
+Creates a new blog post
+
++ Request
+
+    + Headers
+
+            Accept: application/json
+
+            Content-Type: application/json
+
+    + Attributes (BlogPost)
+
++ Response 201 (application/json)
+
+    The created blog post
+
+    + Attributes (BlogPost)
+
++ Response 400 (application/json)
+
+    + Attributes (BadRequest)
+
++ Response 422 (application/json)
+
+    + Attributes (UnprocessableEntity)
+
++ Response 500 (application/json)
+
+  + Attributes (InternalServerError)
+
+### Get all blog posts [GET]
+
+Returns the list of all of the blog posts currently stored in the database
 
 + Request
 
@@ -23,3 +53,105 @@ This path returns the list of all of the blog posts currently stored in the data
     An array of blog posts
 
     + Attributes (array[BlogPost])
+
++ Response 500 (application/json)
+
+  + Attributes (InternalServerError)
+
+## A specific blog post [/posts/{id}]
+
+A blog post that already exists in the database.
+
++ Parameters
+
+    + id: `1` (required, number) - The blog post's database identifier
+
+### Get a blog post [GET]
+
+Returns the list of all of the blog posts currently stored in the database
+
++ Request
+
+    + Headers
+
+            Accept: application/json
+
+    + Body
+
++ Response 200 (application/json)
+
+    An array of blog posts
+
+    + Attributes (array[BlogPost])
+
++ Response 400 (application/json)
+
+  + Attributes (BadRequest)
+
++ Response 404 (application/json)
+
+  + Attributes (NotFound)
+
++ Response 500 (application/json)
+
+  + Attributes (InternalServerError)
+
+### Update a blog post [PUT]
+
+Updates a blog post currently stored in the database
+
++ Request
+
+    + Headers
+
+            Content-Type: application/json
+
+    + Attributes (BlogPost)
+
++ Response 204
+
+    The blog post has been successfully updated
+
+    + Body
+
++ Response 400 (application/json)
+
+  + Attributes (BadRequest)
+
++ Response 422 (application/json)
+
+    + Attributes (UnprocessableEntity)
+
++ Response 500 (application/json)
+
+  + Attributes (InternalServerError)
+
+### Delete a blog post [DELETE]
+
+Deletes a blog post currently stored in the database
+
++ Request
+
+    + Headers
+
+            Accept: application/json
+
+    + Body
+
++ Response 204
+
+    The blog post has been successfully deleted
+
+    + Body
+
++ Response 400 (application/json)
+
+  + Attributes (BadRequest)
+
++ Response 404 (application/json)
+
+    + Attributes (NotFound)
+
++ Response 500 (application/json)
+
+  + Attributes (InternalServerError)

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ func DefaultConfig() Config {
 
 		TrustedSource: "https://samples.auth0.com/",
 
-		MySQLURL: "root:root@tcp(0.0.0.0:3306)/bloggo?charset=utf8&parseTime=True&loc=Local",
+		MySQLURL: "root:root@tcp(db:3306)/bloggo?charset=utf8&parseTime=True&loc=Local",
 	}
 }
 

--- a/controller/blog.go
+++ b/controller/blog.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	errortypes "github.com/Ullaakut/Bloggo/errorTypes"
+	"github.com/Ullaakut/Bloggo/errortypes"
 	"github.com/Ullaakut/Bloggo/model"
 
 	"github.com/labstack/echo"

--- a/controller/blog_test.go
+++ b/controller/blog_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Ullaakut/Bloggo/errorTypes"
+	"github.com/Ullaakut/Bloggo/errortypes"
 	"github.com/Ullaakut/Bloggo/logger"
 	"github.com/Ullaakut/Bloggo/model"
 	"github.com/Ullaakut/Bloggo/repo"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,13 @@ version: '3.1'
 
 services:
 
+  bloggo:
+    build: .
+    ports:
+      - 4242:4242
+    depends_on:
+      - db
+
   db:
     image: mysql
     command: --default-authentication-plugin=mysql_native_password
@@ -14,9 +21,22 @@ services:
     volumes:
       - ./data/blog_posts.sql:/docker-entrypoint-initdb.d/01-blog-posts.sql
       - ./data/users.sql:/docker-entrypoint-initdb.d/02-users.sql
+    healthcheck:
+      test: "mysql --password=\"$$MYSQL_ROOT_PASSWORD\" -e \"use end\""
+      interval: 5s
+      retries: 50
 
   adminer:
     image: adminer
     restart: always
     ports:
       - 8080:8080
+    depends_on:
+      - db
+
+  blueprints:
+    build:
+      context: ./blueprints
+      dockerfile: ./Dockerfile
+    ports:
+      - 3000:3000

--- a/repo/blogPostRepositoryMySQL.go
+++ b/repo/blogPostRepositoryMySQL.go
@@ -1,7 +1,7 @@
 package repo
 
 import (
-	errortypes "github.com/Ullaakut/Bloggo/errorTypes"
+	"github.com/Ullaakut/Bloggo/errortypes"
 	"github.com/Ullaakut/Bloggo/model"
 
 	"github.com/go-sql-driver/mysql"


### PR DESCRIPTION
## Goal of this PR

Reduce the amount of dependencies required to just `docker` and `docker-compose` to use the project.

Also this PR fixes a case issue in the imports that worked on OSX but would break in any other OS.

EDIT: _It seems I somehow reverted the commit containing the API blueprint changes when reverting my accidental push on master (forgot to enable branch protection). This PR also re-adds those changes to master._

When this PR is complete, just running `docker-compose up` should build and start all of the required services:

* Bloggo (port 4242)
* MySQL (port 3306)
* API Documentation (port 3000)
* Adminer (port 8080)

## How to test this PR

Run `docker-compose up` and make sure that all four services are up and are accessible.

* Visit `localhost:3000`, it should display the API documentation
* Use postman or curl to make requests to the API and check that Bloggo is working as it should
* Visit `localhost:8080` to access adminer, and use it to connect to the database. Make sure that it can properly access it.