### PR TITLE
Add UpdatedAt field & change CreatedAt field to datetime in MySQL

### DIFF
--- a/data/blog_posts.sql
+++ b/data/blog_posts.sql
@@ -13,7 +13,8 @@ CREATE TABLE `blog_posts` (
   `title` varchar(255) NOT NULL,
   `content` text NOT NULL,
   `author` varchar(255) NOT NULL,
-  `created_at` date NOT NULL,
+  `updated_at` datetime NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+  `created_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 

--- a/model/blogPost.go
+++ b/model/blogPost.go
@@ -11,7 +11,7 @@ type BlogPost struct {
 	Title     string    `json:"title" validate:"required"`
 	Content   string    `json:"content" validate:"required"`
 	CreatedAt time.Time `json:"created_at,omitempty"`
-	// UpdatedAt time.Time // TODO maybe if I have time
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 	// Comments   []Comment // TODO maybe if I have time
 	// Views   uint // TODO maybe if I have time
 }


### PR DESCRIPTION
<img width="384" alt="screenshot 2018-08-03 at 23 04 12" src="https://user-images.githubusercontent.com/6976628/43665961-419d983a-9772-11e8-9023-e500fd2d7620.png">


## Goal of this PR

Fix a mistake. The MySQL data structure originally used a `date` for `created_at` instead of a `datetime`. This PR also adds an `updated_at` field that is automatically updated when a blog post is updated.

Fixes #41 

## How to test it

* Using the postman collection, create a few blog posts, edit them and get them
* Make sure that the created_at value contains hours, minutes and seconds
* Make sure that the updated_at value is valid & different from the created_at value when a blog post has been edited