### PR TITLE
Improve retry mechanic for db connection (#58)

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,7 +16,9 @@ type Config struct {
 	TrustedSource string
 	JWTSecret     string
 
-	MySQLURL string
+	MySQLURL           string
+	MySQLRetryInterval time.Duration
+	MySQLRetryDuration time.Duration
 }
 
 // DefaultConfig generates a configuration structure with the default values
@@ -29,7 +31,9 @@ func DefaultConfig() Config {
 
 		TrustedSource: "https://samples.auth0.com/",
 
-		MySQLURL: "root:root@tcp(db:3306)/bloggo?charset=utf8&parseTime=True&loc=Local",
+		MySQLURL:           "root:root@tcp(db:3306)/bloggo?charset=utf8&parseTime=True&loc=Local",
+		MySQLRetryInterval: 2 * time.Second,
+		MySQLRetryDuration: 1 * time.Minute,
 	}
 }
 
@@ -41,6 +45,8 @@ func (c Config) Print(log *zerolog.Logger) {
 		Uint("ServerPort", c.ServerPort).
 		Dur("GraciousShutdownTimeout", c.GracefulShutdownTimeout).
 		Str("MySQLURL", c.MySQLURL).
+		Dur("MySQLRetryInterval", c.MySQLRetryInterval).
+		Dur("MySQLRetryDuration", c.MySQLRetryDuration).
 		Str("TrustedSource", c.TrustedSource).
 		Str("JWTSecret", "**************").
 		Msg("Configuration")


### PR DESCRIPTION
<img width="949" alt="screenshot 2018-08-06 at 08 11 59" src="https://user-images.githubusercontent.com/6976628/43700082-a1ba902a-9951-11e8-824d-7d956725f761.png">

## Goal of this PR

Fixes #58 

Improve retry mechanic for database connection
Improve logging when trying / succeeding / failing to connect to MySQL by printing errors

## How to test it

* Run bloggo without the db
* Start the database after a while
* It should succeed

* Run bloggo without the db
* Wait until the end of the retryDuration that is set in the config
* It should fail like this

```
2018-08-06T06:25:17Z |ERRO| operation failed, will retry error="dial tcp: lookup db on 192.168.65.1:53: no such host"
2018-08-06T06:25:19Z |ERRO| operation failed too many times, aborting error="dial tcp: lookup db on 192.168.65.1:53: no such host"
2018-08-06T06:25:19Z |FATA| could not initialize mysql connection error="dial tcp: lookup db on 192.168.65.1:53: no such host"
```

<img width="952" alt="screenshot 2018-08-06 at 08 31 06" src="https://user-images.githubusercontent.com/6976628/43700492-16f5c8e0-9953-11e8-873c-c966d3284450.png">
