### PR TITLE
Improve errortype folder naming by removing uppercase letter & using singular form (#58)

### DIFF
--- a/controller/blog.go
+++ b/controller/blog.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Ullaakut/Bloggo/errortypes"
+	"github.com/Ullaakut/Bloggo/errortype"
 	"github.com/Ullaakut/Bloggo/model"
 
 	"github.com/labstack/echo"
@@ -87,7 +87,7 @@ func (b *Blog) Read(ctx echo.Context) error {
 
 	// retrieve the blog post from the blog post repository
 	blogPost, err := b.posts.Retrieve(uint(id))
-	if errors.Cause(err) == errortypes.ErrNotFound {
+	if errors.Cause(err) == errortype.ErrNotFound {
 		return echo.NewHTTPError(http.StatusNotFound, errors.Wrapf(err, "blog post id %d", id).Error())
 	}
 	if err != nil {
@@ -133,7 +133,7 @@ func (b *Blog) Update(ctx echo.Context) error {
 
 	post.ID = uint(id)
 	err = b.posts.Update(&post)
-	if errors.Cause(err) == errortypes.ErrNotFound {
+	if errors.Cause(err) == errortype.ErrNotFound {
 		return echo.NewHTTPError(http.StatusNotFound, errors.Wrapf(err, "blog post id %d", id).Error())
 	}
 	if err != nil {
@@ -153,7 +153,7 @@ func (b *Blog) Delete(ctx echo.Context) error {
 
 	// delete the blog post from the repository
 	err = b.posts.Delete(uint(id))
-	if errors.Cause(err) == errortypes.ErrNotFound {
+	if errors.Cause(err) == errortype.ErrNotFound {
 		return echo.NewHTTPError(http.StatusNotFound, errors.Wrapf(err, "blog post id %d", id).Error())
 	}
 	if err != nil {

--- a/controller/blog_test.go
+++ b/controller/blog_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Ullaakut/Bloggo/errortypes"
+	"github.com/Ullaakut/Bloggo/errortype"
 	"github.com/Ullaakut/Bloggo/logger"
 	"github.com/Ullaakut/Bloggo/model"
 	"github.com/Ullaakut/Bloggo/repo"
@@ -25,11 +25,11 @@ type ResourceNotFoundErr struct {
 }
 
 func (r *ResourceNotFoundErr) Cause() error {
-	return errortypes.ErrNotFound
+	return errortype.ErrNotFound
 }
 
 func (r *ResourceNotFoundErr) Error() string {
-	return errortypes.ErrNotFound.Error()
+	return errortype.ErrNotFound.Error()
 }
 
 func TestNewBlog(t *testing.T) {

--- a/errortype/errors.go
+++ b/errortype/errors.go
@@ -1,4 +1,4 @@
-package errortypes
+package errortype
 
 import "errors"
 

--- a/repo/blogPostRepositoryMySQL.go
+++ b/repo/blogPostRepositoryMySQL.go
@@ -1,7 +1,7 @@
 package repo
 
 import (
-	"github.com/Ullaakut/Bloggo/errortypes"
+	"github.com/Ullaakut/Bloggo/errortype"
 	"github.com/Ullaakut/Bloggo/model"
 
 	"github.com/go-sql-driver/mysql"
@@ -32,7 +32,7 @@ func (r *BlogPostRepositoryMySQL) Store(post *model.BlogPost) (*model.BlogPost, 
 	if mysqlError, ok := err.(*mysql.MySQLError); ok {
 		// if the error is of type duplicate entry
 		if mysqlError.Number == 1062 {
-			return nil, errortypes.ErrDuplicateEntry
+			return nil, errortype.ErrDuplicateEntry
 		}
 	}
 
@@ -47,7 +47,7 @@ func (r *BlogPostRepositoryMySQL) Retrieve(id uint) (*model.BlogPost, error) {
 
 	err := r.db.Where(&post).First(&post).Error
 	if err == gorm.ErrRecordNotFound {
-		return &post, errortypes.ErrNotFound
+		return &post, errortype.ErrNotFound
 	}
 
 	return &post, err
@@ -69,7 +69,7 @@ func (r *BlogPostRepositoryMySQL) Update(post *model.BlogPost) error {
 	// If not, return an error
 	err := r.db.First(&existingPost, post.ID).Error
 	if err == gorm.ErrRecordNotFound {
-		return errortypes.ErrNotFound
+		return errortype.ErrNotFound
 	}
 	if err != nil {
 		return errors.Wrap(err, "could not get blog post from db")
@@ -94,7 +94,7 @@ func (r *BlogPostRepositoryMySQL) Delete(id uint) error {
 	// Get the blog post to make sure it exists
 	err := r.db.First(&blogPost, id).Error
 	if err == gorm.ErrRecordNotFound {
-		return errortypes.ErrNotFound
+		return errortype.ErrNotFound
 	}
 
 	// If it does, delete it
@@ -102,7 +102,7 @@ func (r *BlogPostRepositoryMySQL) Delete(id uint) error {
 	if mysqlError, ok := err.(*mysql.MySQLError); ok {
 		// foreign key failure
 		if mysqlError.Number == 1451 {
-			return errors.Wrap(errortypes.ErrConflict, err.Error())
+			return errors.Wrap(errortype.ErrConflict, err.Error())
 		}
 	}
 	return err


### PR DESCRIPTION
<img width="567" alt="screenshot 2018-08-06 at 09 06 28" src="https://user-images.githubusercontent.com/6976628/43701856-093d7658-9958-11e8-8324-c349cbd4d5a3.png">

Folder structure is cleaner now.

## Goal of this PR

Improve consistency by using singular form for errortype folder name
Improve consistency by using singular form for errortype package
Improve consistency by removing uppercase letter from errortype folder name

## How to test it

* `docker-compose build`
* `docker-compose up`
* `go test controller/*.go -cover`
* `go test service/*.go -cover`
* If it compiles, runs and that the tests are passing, this probably didn't break anything