### PR TITLE
Hash passwords (#70)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bloggo
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.html
 
 # Vendor
 /vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 
 script:
 # Run unit tests
-- go test github.com/Ullaakut/Bloggo/controller/ github.com/Ullaakut/Bloggo/service/ -v -covermode=count -coverprofile=coverage.out
+- go test github.com/Ullaakut/Bloggo/controller/ github.com/Ullaakut/Bloggo/service/ -v -covermode=count -coverprofile=coverage.out | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''
 - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
 # Run bloggo for a few secs until it is connected to the db
 - docker-compose up -d

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -258,11 +258,13 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:507fa82feeba6c3651d3cfb7593a498144ae6455e1b00dde2e0c344cdfdc9c4d"
+  digest = "1:e1aae46de34bee07d3c3733f9b7ccb45959c8ee909bbff69fbd2169ec109c1bf"
   name = "golang.org/x/crypto"
   packages = [
     "acme",
     "acme/autocert",
+    "bcrypt",
+    "blowfish",
   ]
   pruneopts = "UT"
   revision = "88942b9c40a4c9d203b82b3731787b672d6e809b"
@@ -336,6 +338,7 @@
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
+    "golang.org/x/crypto/bcrypt",
     "gopkg.in/go-playground/validator.v9",
     "gopkg.in/tylerb/graceful.v1",
   ]

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Examples: `192.168.0.5`, `localhost`, `10.15.17.160`...
 
 Sets the port used by the API. Default value is `4242`.
 
-Can be any value between 1 and 65535.
+Can be any value between `1` and `65535`.
 
 ### `BLOGGO_MYSQL_URL`
 
@@ -142,6 +142,12 @@ Examples: `1s`, `10m`, `24h`, `7d`, ...
 Sets the interval between each reconnection attempt to MySQL within the retry duration. Default value is `2s` (two seconds).
 
 Examples: `1s`, `10m`, `24h`, `7d`, ...
+
+### `BLOGGO_BCRYPT_RUNS`
+
+Sets the number of iterations of hashing that the bcrypt algorithm will run when hashing passwords. Default value is `11`.
+
+Can be any value between `4` and `31`.
 
 ## License
 

--- a/bloggo.go
+++ b/bloggo.go
@@ -67,11 +67,13 @@ func main() {
 	blogPostRepository := repo.NewBlogPostRepositoryMySQL(log, db)
 	userRepository := repo.NewUserRepositoryMySQL(log, db)
 
+	hasher := service.NewBcryptHasher(config.BcryptRuns)
+
 	accessService := service.NewAccess(log, userRepository, config.jwtSecret)
-	tokenService := service.NewToken(log, userRepository, config.jwtSecret)
+	tokenService := service.NewToken(log, userRepository, hasher, config.jwtSecret)
 
 	blogController := controller.NewBlog(log, blogPostRepository)
-	userController := controller.NewUser(log, userRepository, tokenService)
+	userController := controller.NewUser(log, userRepository, tokenService, hasher)
 	authController := controller.NewAuth(log, accessService)
 
 	// Bind routes to controller methods

--- a/config.go
+++ b/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	MySQLRetryInterval time.Duration `json:"mysql_retry_interval"`
 	MySQLRetryDuration time.Duration `json:"mysql_retry_duration"`
 
+	BcryptRuns int `json:"bcrypt_runs"`
+
 	jwtSecret string
 }
 
@@ -28,6 +30,7 @@ func init() {
 	viper.SetDefault("mysql_url", "root:root@tcp(db:3306)/bloggo?charset=utf8&parseTime=True&loc=Local")
 	viper.SetDefault("mysql_retry_interval", "2s")
 	viper.SetDefault("mysql_retry_duration", "1m")
+	viper.SetDefault("bcrypt_runs", 11)
 }
 
 // GetConfig sets the default values for the configuration and gets it from the environment/command line
@@ -49,17 +52,20 @@ func GetConfig() Config {
 	config.MySQLRetryInterval = viper.GetDuration("mysql_retry_interval")
 	config.MySQLRetryDuration = viper.GetDuration("mysql_retry_duration")
 
+	config.BcryptRuns = viper.GetInt("bcrypt_runs")
+
 	return config
 }
 
 // Print prints the current configuration
 func (c Config) Print(log *zerolog.Logger) {
 	log.Debug().
-		Str("LogLevel", c.LogLevel).
-		Str("ServerAddress", c.ServerAddress).
-		Uint("ServerPort", c.ServerPort).
-		Str("MySQLURL", c.MySQLURL).
-		Dur("MySQLRetryInterval", c.MySQLRetryInterval).
-		Dur("MySQLRetryDuration", c.MySQLRetryDuration).
-		Msg("Configuration")
+		Str("log_level", c.LogLevel).
+		Str("server_address", c.ServerAddress).
+		Uint("server_port", c.ServerPort).
+		Str("mysql_url", c.MySQLURL).
+		Dur("mysql_retry_interval", c.MySQLRetryInterval).
+		Dur("mysql_retry_duration", c.MySQLRetryDuration).
+		Int("bcrypt_runs", c.BcryptRuns).
+		Msg("configuration")
 }

--- a/godoc.go
+++ b/godoc.go
@@ -1,0 +1,10 @@
+// Bloggo is a self-hosted blogging CMS. It is fast and simple.
+//
+// For the code documentation, see those packages:
+// https://godoc.org/github.com/Ullaakut/Bloggo/controller
+// https://godoc.org/github.com/Ullaakut/Bloggo/service
+// https://godoc.org/github.com/Ullaakut/Bloggo/repo
+// https://godoc.org/github.com/Ullaakut/Bloggo/logger
+// https://godoc.org/github.com/Ullaakut/Bloggo/errortype
+
+package main

--- a/service/hasher.go
+++ b/service/hasher.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Hasher describes something that can hash passwords
+type Hasher interface {
+	Hash(password string) (string, error)
+}
+
+// HashComparer describes something that can compare hashed passwords with clear passwords
+type HashComparer interface {
+	Compare(hash, password string) error
+}
+
+// HasherComparer describes something that can hash passwords and compare them with clear passwords
+type HasherComparer interface {
+	Hash(password string) (string, error)
+	Compare(hash, password string) error
+}
+
+// BcryptHasher implements the Hasher and HashComparer interfaces and uses Provos and
+// Mazières's bcrypt adaptive hashing algorithm
+type BcryptHasher struct {
+	runs int
+}
+
+// NewBcryptHasher instanciates a BcryptHasher and sets its number of runs
+func NewBcryptHasher(runs int) HasherComparer {
+	return &BcryptHasher{
+		runs: runs,
+	}
+}
+
+// Hash hashes a password
+func (bh *BcryptHasher) Hash(password string) (string, error) {
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bh.runs)
+	return string(hashedPassword), err
+}
+
+// Compare compares a hashed password to a clear password
+func (bh *BcryptHasher) Compare(hash, password string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+}

--- a/service/hasher_test.go
+++ b/service/hasher_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBcryptHasher(t *testing.T) {
+	NewBcryptHasher(42)
+}
+
+func TestHash(t *testing.T) {
+	tests := []struct {
+		description string
+
+		password string
+
+		expectedHashBeginning string
+		expectedHashLength    int
+		expectedErr           error
+	}{
+		{
+			description: "valid test",
+
+			password: "test",
+
+			expectedHashBeginning: "$2a$11",
+			expectedHashLength:    len("$2a$11$99n/E61OMEtfFRsyrvHb6uvB80wrOCCV6zXRxujItx7zh.jJeiFpW"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			hasher := &BcryptHasher{
+				runs: 11,
+			}
+
+			hash, err := hasher.Hash(test.password)
+			if err != nil {
+				assert.Equal(t, test.expectedErr, err, "unexpected error")
+			} else {
+				assert.Equal(t, test.expectedHashBeginning, hash[0:6], "unexpected hash beginning")
+				assert.Equal(t, test.expectedHashLength, len(hash), "unexpected hash length")
+			}
+		})
+	}
+}
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		description string
+
+		password string
+		hash     string
+
+		expectedErr error
+	}{
+		{
+			description: "valid test",
+
+			password: "test",
+			hash:     "$2a$11$tP88VYt33B1vvCnzdm9UO.x/gVTxcB8mUtWma0/ba9YbZ6s51.r2y",
+
+			expectedErr: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			hasher := &BcryptHasher{
+				runs: 11,
+			}
+
+			err := hasher.Compare(test.hash, test.password)
+			assert.Equal(t, test.expectedErr, err, "unexpected error")
+		})
+	}
+}


### PR DESCRIPTION
## Goal of this PR

Fixes #70 

This PR adds `bcrypt` password hashing to Bloggo, as well as a new configuration variable for the number of iterations of the hashing algorithm (higher is more secure but more CPU intensive)

## How to test this PR

* `docker-compose up`
* Using the postman collection, create a new user
* Using `adminer` (available by visiting [localhost:8080](http://localhost:8080), visit the `users` table. The passwords should be hashed.
* Login by sending the plain text password, it should work.

## Screenshots

<img width="822" alt="screenshot 2018-09-13 at 07 52 25" src="https://user-images.githubusercontent.com/6976628/45469477-01b5c800-b72a-11e8-83f5-95b039b96aee.png">
