### PR TITLE
Fix HasherComparer interface

### DIFF
--- a/service/hasher.go
+++ b/service/hasher.go
@@ -16,8 +16,8 @@ type HashComparer interface {
 
 // HasherComparer describes something that can hash passwords and compare them with clear passwords
 type HasherComparer interface {
-	Hash(password string) (string, error)
-	Compare(hash, password string) error
+	Hasher
+	HashComparer
 }
 
 // BcryptHasher implements the Hasher and HashComparer interfaces and uses Provos and


### PR DESCRIPTION
## Goal of this PR

This PR makes the HasherComparer interface more idiomatic and DRY, by replacing the function it has to implement with the definition of both interfaces that compose it.

## How to test it

Just a code improvement, no impact whatsoever on anything else than readability and code quality.