### PR TITLE
Dockerize frontend & deploy it with nginx (#50) (#69)

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,15 @@
+FROM nginx:alpine
+
+COPY index.html /usr/share/nginx/html
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY grid.scss .
+
+RUN apk update && \
+    apk upgrade && \
+    apk add nodejs
+RUN npm install -g sass
+RUN sass grid.scss /usr/share/nginx/html/grid.css
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/app/nginx/nginx.conf
+++ b/app/nginx/nginx.conf
@@ -1,0 +1,44 @@
+events {}
+
+http {
+	server {
+
+		gzip on;
+		gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+		listen        80;
+		error_log     /var/log/nginx/error.log;
+
+		root /usr/share/nginx/html;
+
+		rewrite  ^/$  /index.html  last;
+
+		location / {
+			include /etc/nginx/mime.types;
+
+			if ($request_method = 'OPTIONS') {
+				add_header 'Access-Control-Allow-Origin' '*';
+				add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+				add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+				add_header 'Access-Control-Max-Age' 1728000;
+				add_header 'Content-Type' 'text/plain; charset=utf-8';
+				add_header 'Content-Length' 0;
+				return 204;
+			}
+
+			if ($request_method = 'POST') {
+				add_header 'Access-Control-Allow-Origin' '*';
+				add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+				add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+				add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+			}
+
+			if ($request_method = 'GET') {
+				add_header 'Access-Control-Allow-Origin' '*';
+				add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+				add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+				add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+			}
+		}
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,15 @@ services:
     depends_on:
       - db
 
+  app:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    ports:
+      - 80:80
+    depends_on:
+      - bloggo
+
   db:
     image: mysql
     command: --default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
## Goal of this PR

* Dockerizes the frontend to make it deployable along with the rest of bloggo on any OS
* Uses nginx to serve it in order to have caching, compression and other features out of the box

Fixes #50 
Fixes #69 

## How to test it

1. `docker-compose build`
2. `docker-compose up`
3. Visit `localhost` in your favorite browser
4. You should be seeing the frontend with the compiled `sass`.

## Screenshots

<img width="630" alt="screenshot 2018-09-14 at 17 19 16" src="https://user-images.githubusercontent.com/6976628/45559282-55b3d000-b842-11e8-9a68-591b40a86e96.png">
