### PR TITLE
Add README.md files in subfolders (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,7 @@ To set the configuration values, you need to set environment variables. See the 
 
 ## API Blueprints
 
-* `docker-compose up blueprints`
-* Visit `0.0.0.0:3000` in your favorite browser
-
-<p align="center">
-    <img width="500"  src="images/blueprints.png">
-</p>
+See [the README.md file for the blueprints](blueprints/README.md).
 
 ## Postman collection
 

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,43 @@
+# Bloggo app frontend
+
+This folder contains the sources of the frontend, as well as the Dockerfile and nginx configuration to deploy it.
+
+## Webapp
+
+The style is built using `sass`, and the HTML is just static HTML. We might use React in the future when we need the interface to become more complex.
+
+To compile the style, you can either use the docker image to avoid installing dependencies on your computer, or you can use the sass compiler.
+
+### Sass installation
+
+#### Standalone
+
+You can install Sass on Windows, Mac, or Linux by downloading the package for your operating system from [GitHub](https://github.com/sass/dart-sass/releases/tag/1.13.4) and [adding it to your PATH](https://katiek2.github.io/path-doc/). That's all—there are no external dependencies and nothing else you need to install.
+
+#### npm install
+
+If you use Node.js, you can also install Sass using npm by running
+
+`npm install -g sass`
+
+However, please note that this will install the pure JavaScript implementation of Sass, which runs somewhat slower than the other options listed here. But it has the same interface, so it'll be easy to swap in another implementation later if you need a bit more speed!
+
+#### Install on Windows
+
+If you use the Chocolatey package manager for Windows, you can install Dart Sass by running
+
+`choco install sass`
+
+#### Install on Mac OS X
+
+If you use the Homebrew package manager for Mac OS X, you can install Dart Sass by running
+
+`brew install sass/sass/sass`
+
+## Deployment
+
+The Dockerfile simply compiles the `sass` and serves the folder as static files.
+
+## Nginx configuration
+
+Deploying the app with nginx allows to enable gzip compression, URL rewrite, etc.

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -1,0 +1,25 @@
+# API documentation
+
+The blueprints represent the API's documentation.
+
+They document for each route:
+
+* The supported methods
+* The expected inputs
+* The API's responses
+
+## How to build the blueprints
+
+The simplest way is to use the docker image, either by running `docker build -t . blueprints` or by using the `docker-compose.yml` file at the root of the repository and running `docker-compose up blueprints`
+
+You can also build them yourself by installing `nodejs`, and running `npm install -g aglio`, and then running `aglio -h 0.0.0.0 -i main.apib --theme-variables slate -s`
+
+## How to access the blueprints
+
+Once they are deployed, you can find the blueprints in your browser by accessing `http://0.0.0.0:3000`
+
+## Screenshots
+
+<p align="center">
+    <img width="500"  src="../images/blueprints.png">
+</p>

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,5 @@
+# Data folder
+
+This folder contains the data that is loaded into the docker containers.
+
+For now, this just consists of SQL files to create the database tables.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,7 @@
+# Functional tests
+
+This folder contains functional tests that are ran by the CI. They are not stateless, and thus will only work on a fresh DB once. Then, they won't function properly again unless the database is purged and the automatically incrementing indexes are reset.
+
+## Purpose of the tests
+
+Unit tests are good, but I feel like it's safer to validate that the whole API is still behaving like it should. These tests ensure that the software itself responds properly, given a set of inputs.


### PR DESCRIPTION
## Goal of this PR

This PR adds documentation in some sub folders, giving explanations on their purpose and how to use their contents. This will make it easier for people to be able to contribute in the future, and will avoid making the root `README.md` file too big.

Fixes #86 