### PR TITLE
Remove legacy entries from ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ The idea is to use a fast and simple language for the backend, Go, and a simple 
 * [API Blueprints](#api-blueprints)
 * [Postman collection](#postman-collection)
 * [Testing](#testing)
-* [Possible future improvements](#possible-future-improvements)
-* [Notes & technical choices](#notes-and-technical-choices)
 * [Environment configuration](#environment)
 * [License](#license)
 


### PR DESCRIPTION
## Goal of this PR

Remove two entries in the `Table of Contents` of the `README.md` file at the root of the repository, since they are no longer pointing to anything.