### PR TITLE
Remove unnecessary update time logic from go code

### DIFF
--- a/controller/blog.go
+++ b/controller/blog.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/Ullaakut/Bloggo/errortype"
 	"github.com/Ullaakut/Bloggo/model"
@@ -64,9 +63,6 @@ func (b *Blog) Create(ctx echo.Context) error {
 	// Set the author to the user ID so that the API can't be used manually
 	// to claim that a post was created by another user
 	post.Author = userID
-
-	// Set createdAt value to now
-	post.CreatedAt = time.Now()
 
 	createdPost, err := b.posts.Store(&post)
 	if err != nil {

--- a/data/sql/blog_posts.sql
+++ b/data/sql/blog_posts.sql
@@ -13,8 +13,8 @@ CREATE TABLE `blog_posts` (
   `title` varchar(255) NOT NULL,
   `content` text NOT NULL,
   `author` varchar(255) NOT NULL,
-  `updated_at` datetime NOT NULL ON UPDATE CURRENT_TIMESTAMP,
-  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 

--- a/model/blogPost.go
+++ b/model/blogPost.go
@@ -12,12 +12,4 @@ type BlogPost struct {
 	Content   string    `json:"content" validate:"required"`
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
-	// Comments   []Comment // TODO maybe if I have time
-	// Views   uint // TODO maybe if I have time
 }
-
-// type Comment struct {
-// 	Author      string
-// 	Content     string
-// 	CreatedDate time.Time
-// }


### PR DESCRIPTION
## Goal of this PR

I recently discovered that MySQL can now handle multiple TIMESTAMP fields per table. This was not the case before, which is why I originally designed the scheme using a MySQL TIMESTAMP on update for the `updated_at` field and manually set the `created_at` field from the API.

It is not necessary, and just changing the scheme allows to remove a few useless lines in the API.

Fixes #93 

## How to test it

* `docker-compose up`
* Using the postman collection, create a admin account, login and create a few posts
* Edit one of them
* List all posts and verify that the values for `created_at` and `updated_at` are correct